### PR TITLE
Add Retell flow schema

### DIFF
--- a/livekit-agents/livekit/agents/flow/hybrid_flow.py
+++ b/livekit-agents/livekit/agents/flow/hybrid_flow.py
@@ -1,0 +1,66 @@
+import asyncio
+from typing import Callable, Optional
+
+from livekit.agents import Agent, AgentSession, AgentTask, RunContext
+from livekit.agents.llm.chat_context import ChatMessage
+from livekit.agents.voice.agent import _set_activity_task_info
+
+from .schema import FlowSpec, Node, load_flow
+
+
+class ConversationTask(AgentTask[str]):
+    def __init__(self, node: Node) -> None:
+        super().__init__(instructions="")
+        self.node = node
+
+    async def on_enter(self) -> None:
+        if self.node.instruction:
+            if self.node.instruction.type == "prompt":
+                self.session.generate_reply(instructions=self.node.instruction.text)
+            else:
+                self.session.say(self.node.instruction.text)
+
+    async def on_user_turn_completed(
+        self, ctx: RunContext, new_message: ChatMessage
+    ) -> None:
+        self.complete(new_message.text_content)
+
+
+class FlowRunner:
+    def __init__(
+        self,
+        path: str,
+        edge_evaluator: Callable[[Node, str | None], Optional[str]],
+    ) -> None:
+        self.flow: FlowSpec = load_flow(path)
+        self.edge_evaluator = edge_evaluator
+
+    async def run(self, session: AgentSession) -> None:
+        node_id: Optional[str] = self.flow.start_node_id
+        last_result: str | None = None
+        while node_id:
+            node = self.flow.nodes[node_id]
+            if node.type == "conversation" and node.instruction is not None:
+                result = await ConversationTask(node)
+            else:
+                if node.type == "end" and node.instruction is not None:
+                    if node.instruction.type == "prompt":
+                        session.generate_reply(instructions=node.instruction.text)
+                    else:
+                        session.say(node.instruction.text)
+                break
+            last_result = result
+            node_id = self.edge_evaluator(node, last_result)
+
+
+
+class FlowAgent(Agent):
+    def __init__(
+        self, path: str, edge_evaluator: Callable[[Node, str | None], Optional[str]]
+    ) -> None:
+        super().__init__(instructions="")
+        self.runner = FlowRunner(path, edge_evaluator)
+
+    async def on_enter(self) -> None:
+        _set_activity_task_info(asyncio.current_task(), inline_task=True)
+        await self.runner.run(self.session)

--- a/livekit-agents/livekit/agents/flow/schema.py
+++ b/livekit-agents/livekit/agents/flow/schema.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Instruction:
+    type: str
+    text: str
+
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> Instruction:
+        return Instruction(type=d.get("type", ""), text=d.get("text", ""))
+
+
+@dataclass
+class TransitionCondition:
+    type: str
+    prompt: str
+
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> TransitionCondition:
+        return TransitionCondition(type=d.get("type", ""), prompt=d.get("prompt", ""))
+
+
+@dataclass
+class Edge:
+    id: str
+    condition: str
+    transition_condition: TransitionCondition
+    destination_node_id: str | None = None
+
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> Edge:
+        tc = d.get("transition_condition", {})
+        return Edge(
+            id=d.get("id", ""),
+            condition=d.get("condition", ""),
+            transition_condition=TransitionCondition.from_dict(tc),
+            destination_node_id=d.get("destination_node_id"),
+        )
+
+
+@dataclass
+class GlobalNodeSetting:
+    condition: str
+
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> GlobalNodeSetting:
+        return GlobalNodeSetting(condition=d.get("condition", ""))
+
+
+@dataclass
+class Node:
+    id: str
+    name: str
+    type: str
+    instruction: Instruction | None = None
+    tool_id: str | None = None
+    tool_type: str | None = None
+    speak_during_execution: bool | None = None
+    wait_for_result: bool | None = None
+    edges: list[Edge] = field(default_factory=list)
+    skip_response_edge: Edge | None = None
+    global_node_setting: GlobalNodeSetting | None = None
+
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> Node:
+        instruction = d.get("instruction")
+        if instruction is not None:
+            instruction = Instruction.from_dict(instruction)
+        skip = d.get("skip_response_edge")
+        if skip is not None:
+            skip = Edge.from_dict(skip)
+        global_setting = d.get("global_node_setting")
+        if global_setting is not None:
+            global_setting = GlobalNodeSetting.from_dict(global_setting)
+        edges = [Edge.from_dict(e) for e in d.get("edges", [])]
+        return Node(
+            id=d["id"],
+            name=d.get("name", ""),
+            type=d.get("type", ""),
+            instruction=instruction,
+            tool_id=d.get("tool_id"),
+            tool_type=d.get("tool_type"),
+            speak_during_execution=d.get("speak_during_execution"),
+            wait_for_result=d.get("wait_for_result"),
+            edges=edges,
+            skip_response_edge=skip,
+            global_node_setting=global_setting,
+        )
+
+
+@dataclass
+class ToolSpec:
+    name: str
+    description: str
+    tool_id: str
+    type: str
+    parameters: dict[str, Any]
+    url: str | None = None
+
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> ToolSpec:
+        return ToolSpec(
+            name=d.get("name", ""),
+            description=d.get("description", ""),
+            tool_id=d.get("tool_id", ""),
+            type=d.get("type", ""),
+            parameters=d.get("parameters", {}),
+            url=d.get("url"),
+        )
+
+
+@dataclass
+class FlowSpec:
+    conversation_flow_id: str
+    version: int
+    global_prompt: str
+    nodes: dict[str, Node]
+    start_node_id: str
+    start_speaker: str | None = None
+    tools: dict[str, ToolSpec] = field(default_factory=dict)
+    model_choice: dict[str, Any] | None = None
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> FlowSpec:
+        nodes = {n["id"]: Node.from_dict(n) for n in data.get("nodes", [])}
+        tools = {t["tool_id"]: ToolSpec.from_dict(t) for t in data.get("tools", [])}
+        return FlowSpec(
+            conversation_flow_id=data.get("conversation_flow_id", ""),
+            version=data.get("version", 0),
+            global_prompt=data.get("global_prompt", ""),
+            nodes=nodes,
+            start_node_id=data.get("start_node_id", ""),
+            start_speaker=data.get("start_speaker"),
+            tools=tools,
+            model_choice=data.get("model_choice"),
+        )
+
+
+def load_flow(path: str) -> FlowSpec:
+    import json
+
+    with open(path) as f:
+        data = json.load(f)
+    return FlowSpec.from_dict(data)

--- a/tests/test_retell_flow.py
+++ b/tests/test_retell_flow.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from livekit.agents.flow.hybrid_flow import FlowRunner
+from livekit.agents.flow.schema import Node
+
+
+class DummySession:
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def say(self, text: str) -> None:
+        self.messages.append(text)
+
+
+async def test_flow_runner_basic():
+    path = Path("livekit-agents/livekit/agents/flow/retell.json")
+
+    def evaluator(node: Node, user_input: str | None) -> str | None:
+        if node.id == "start-node-1735257992613":
+            return "node-1735258172746"
+        if node.id == "node-1735258172746":
+            return "node-1736564330428"
+        return None
+
+    runner = FlowRunner(str(path), evaluator)
+    # manually step through a few nodes to verify parsing and evaluator
+    start_node = runner.flow.nodes[runner.flow.start_node_id]
+    assert start_node.instruction.text.startswith("Hello this is Retell")
+    assert start_node.instruction.type == "static_text"
+
+    next_id = evaluator(start_node, None)
+    next_node = runner.flow.nodes[next_id]
+    assert next_node.instruction.text.startswith("Ask user what's the reason")
+    assert next_node.instruction.type == "prompt"


### PR DESCRIPTION
## Summary
- define dataclasses in a `schema` module for Retell-style flows
- rework FlowRunner to load `FlowSpec` from JSON
- adjust ConversationTask to use Instruction objects
- update unit test to check parsed schema

## Testing
- `ruff check livekit-agents/livekit/agents/flow/hybrid_flow.py tests/test_retell_flow.py livekit-agents/livekit/agents/flow/schema.py`
- `PYTHONPATH=livekit-agents pytest tests/test_retell_flow.py -q` *(fails: ImportError: cannot import name 'rtc' from 'livekit')*

------
https://chatgpt.com/codex/tasks/task_e_685bdecfdd008328b32d9a5d3c984e95